### PR TITLE
Swift-style not Obj-C style logging.

### DIFF
--- a/Safari FIDO U2F/ViewController.swift
+++ b/Safari FIDO U2F/ViewController.swift
@@ -39,7 +39,7 @@ class ViewController: NSViewController {
         SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: EXT_ID) { (state, error) in
             NSLog("extension: \(state), \(error)")
             if error != nil {
-                print("Error determining the state of extension: %@", error);
+                print("Error determining the state of extension: \(error)");
                 return;
             }
             


### PR DESCRIPTION
Small fix to some logging, which was using Obj-C style %@ instead of Swift \().