### PR TITLE
Check if the data contains the string “u2f_safari2window” before trying to decode it as JSON

### DIFF
--- a/Safari FIDO U2F Extension/bridge.js
+++ b/Safari FIDO U2F Extension/bridge.js
@@ -1,12 +1,14 @@
 // act as bridge between u2f.js and app extension
 
 window.addEventListener("message", function(e) {
-    if (e.origin != window.location.origin)
-        return;
-    var data = JSON.parse(e.data);
-    if (data._meta != "u2f_window2safari")
-        return;
-    safari.extension.dispatchMessage(data.name, data.message);
+    if (e.origin == window.location.origin) {
+        if (e.data.includes("u2f_window2safari")) { // if the data includes our tag, it's safe to parse it as JSON
+            var data = JSON.parse(e.data);
+            if (data._meta == "u2f_window2safari") {
+                safari.extension.dispatchMessage(data.name, data.message);
+            }
+        }
+    }
 });
 
 safari.self.addEventListener("message", function(e) {

--- a/Safari FIDO U2F Extension/u2f.js
+++ b/Safari FIDO U2F Extension/u2f.js
@@ -132,6 +132,10 @@
     window.addEventListener("message", function(e) {
         if (e.origin != window.location.origin)
             return;
+
+        if (!e.data.includes("u2f_safari2window")) // if the data includes our tag, it's safe to parse it as JSON
+            return;
+
         var data = JSON.parse(e.data);
         if (data._meta != "u2f_safari2window" || data.name != "response")
             return;


### PR DESCRIPTION
This avoids throwing exceptions for stuff that is nothing to do with us and therefore isn’t JSON.