### PR TITLE
Should fix #17

### DIFF
--- a/Safari FIDO U2F Extension/u2f.js
+++ b/Safari FIDO U2F Extension/u2f.js
@@ -1,5 +1,5 @@
 (function() {
-    var u2f = {};
+    var u2f = u2f || {};
 
     u2f._pending = null;
 

--- a/Safari FIDO U2F Extension/u2f.js
+++ b/Safari FIDO U2F Extension/u2f.js
@@ -1,5 +1,5 @@
 (function() {
-    var u2f = u2f || {};
+    var u2f = window.u2f || {};
 
     u2f._pending = null;
 


### PR DESCRIPTION
As I mentioned here: https://github.com/Safari-FIDO-U2F/Safari-FIDO-U2F/issues/17 this should fix cases where other implementations add their own stuff to the `u2f` namespace. Basically make the `u2f` var the existing one if it exists, otherwise define a new empty object.