### PR TITLE
Fix README so links are properly closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 To just test the extension without building it:
 
-- Download [the latest release](https://github.com/Safari-FIDO-U2F/Safari-FIDO-U2F/releases
+- Download [the latest release](https://github.com/Safari-FIDO-U2F/Safari-FIDO-U2F/releases)
 - Run It
 - Click `Open Safari Preferences`
 - Enable the `Safari FIDO U2F Extension`


### PR DESCRIPTION
Currently `)` is not closed so markdown link is broken. Fixes that.

Very small change, yeah.